### PR TITLE
Allow for a broker/server offset to enable joint clustering.

### DIFF
--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -114,6 +114,8 @@ spec:
           value: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
         - name: CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS
           value: {{ printf "PLAINTEXT://%s:9092" (include "cp-kafka.cp-kafka-headless.fullname" .) | quote }}
+        - name: KAFKA_BROKER_ID_OFFSET
+          value: {{ .Values.brokerIdOffset | quote }}
         {{- range $key, $value := .Values.configurationOverrides }}
         - name: {{ printf "KAFKA_%s" $key | replace "." "_" | upper | quote }}
           value: {{ $value | quote }}
@@ -134,7 +136,7 @@ spec:
         - sh
         - -exc
         - |
-          export KAFKA_BROKER_ID=${HOSTNAME##*-} && \
+          export KAFKA_BROKER_ID=$((${HOSTNAME##*-}+${KAFKA_BROKER_ID_OFFSET})) && \
           export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${POD_IP}:9092{{ if kindIs "string" $advertisedListenersOverride }}{{ printf ",%s" $advertisedListenersOverride }}{{ end }} && \
           {{ .Values.rackAware.enabled }} && export KAFKA_BROKER_RACK=$(curl -sSk -H "Authorization: Bearer `cat /var/run/secrets/kubernetes.io/serviceaccount/token`" https://kubernetes.default/api/v1/nodes/$NODE_NAME|grep failure-domain.beta.kubernetes.io/zone | sed 's/.*: "\(.*\)",/\1/') ; \
           exec /etc/confluent/docker/run

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -9,6 +9,10 @@
 ## Number of Kafka brokers
 brokers: 3
 
+## The offset at which to begin broker IDs
+## Useful for replicating data between clusters
+brokerIdOffset: 0
+
 ## Image Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-kafka/
 image: confluentinc/cp-enterprise-kafka

--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -105,19 +105,25 @@ spec:
         - name: ZOOKEEPER_CLIENT_PORT
           value: "{{ .Values.clientPort }}"
         - name : ZOOKEEPER_SERVERS
+          {{- if .Values.serverListOverride }}
+          value: {{ .Values.serverListOverride }}
+          {{- else }}
           value: {{ template "cp-zookeeper.serverlist" . }}
+          {{- end }}
         # ZOOKEEPER_SERVER_ID is required just to pass cp-zookeeper ensure script for env check,
         # the value(metadata.mame) is not used and will be overwritten in command part
         - name: ZOOKEEPER_SERVER_ID
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ZOOKEEPER_SERVER_ID_OFFSET
+          value: {{ .Values.serverIdOffset | quote }}
         command:
         - "bash"
         - "-c"
         - |
           ZK_FIX_HOST_REGEX="s/${HOSTNAME}\.[^:]*:/0.0.0.0:/g"
-          ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-}+1)) \
+          ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-}+1+${ZOOKEEPER_SERVER_ID_OFFSET})) \
           ZOOKEEPER_SERVERS=`echo $ZOOKEEPER_SERVERS | sed -e "$ZK_FIX_HOST_REGEX"` \
           /etc/confluent/docker/run
         volumeMounts:

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -9,6 +9,10 @@
 ## Number of zookeeper servers, should be odd number
 servers: 3
 
+## The offset at which to begin server IDs
+## Useful for replicating data between clusters
+serverOffsetId: 0
+
 ## Minimum number of servers available to ensure the availability of zookeeper service
 ## minAvailable: 2
 


### PR DESCRIPTION
When migrating between clusters using a workflow similar to [this one](https://medium.com/naukri-engineering/how-to-migrate-kafka-cluster-to-new-set-of-hardware-with-no-downtime-60fc54ed3ba1), offsets are needed to ensure broker/server IDs do not collide when joining an existing cluster.
