### PR TITLE
Add ability to specify Pod security context to kafka and zookeeper

### DIFF
--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -168,6 +168,10 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+{{ toYaml .Values.securityContext.spec | indent 8 }}
+      {{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
   {{- $disksPerBroker := .Values.persistence.disksPerBroker | int }}

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -101,6 +101,15 @@ podAnnotations: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 nodeSelector: {}
 
+## Whether or not to apply a security context to the StatefulSet pods, and the specification
+## of that security context.
+securityContext:
+  enabled: false
+  spec:
+    runAsUser: 5000
+    runAsGroup: 5000
+    fsGroup: 5000
+
 ## Taints to tolerate on node assignment:
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: {}

--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -155,6 +155,10 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+{{ toYaml .Values.securityContext.spec | indent 8 }}
+      {{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -99,6 +99,15 @@ headlessServiceAnnotations: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 nodeSelector: {}
 
+## Whether or not to apply a security context to the StatefulSet pods, and the specification
+## of that security context.
+securityContext:
+  enabled: false
+  spec:
+    runAsUser: 5000
+    runAsGroup: 5000
+    fsGroup: 5000
+
 ## Taints to tolerate on node assignment:
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: {}


### PR DESCRIPTION
The approach here is to have a flag that will enable/disable the addition of a `securityContext` field in the pod template of each StatefulSet spec. The entire spec can be overridden under the `securityContext.spec` field, with defaults for `runAsGroup`, `runAsUser`, and `fsGroup`. The defaults are based on (an as-yet undocumented) idea I had to make all our container uids be in the range 5000-10000 to avoid overlap with host users. This is especially important because we haven't enabled user namespaces in the docker engine config on the CoreOS k8s nodes yet, so a uid/gid inside a container is the same uid/gid outside the container.