### PR TITLE
INF-2266: Add KAFKA_DATA_DIRS to kafka environment

### DIFF
--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -110,6 +110,10 @@ spec:
           value: {{ include "cp-kafka.cp-zookeeper.service-name" . | quote }}
         - name: KAFKA_LOG_DIRS
           value: {{ include "cp-kafka.log.dirs" . | quote }}
+          # Workaround a regression in the confluent image
+          # https://github.com/confluentinc/cp-docker-images/issues/653
+        - name: KAFKA_DATA_DIRS
+          value: {{ include "cp-kafka.log.dirs" . | quote }}
         - name: KAFKA_METRIC_REPORTERS
           value: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
         - name: CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS


### PR DESCRIPTION
There's a bug in the image that will check the writability of the
directories in the environment variable KAFKA_DATA_DIRS (and
interestingly, does _not_ check the writability of KAFKA_LOG_DIRS). The
image will default KAFKA_DATA_DIRS to `/var/lib/kafka/data` if not set,
which is not a writable directory when running with a read-only root
filesystem unless a volume is mounted there. Since KAFKA_DATA_DIRS is
ignored beyond the initial writability check, it seems just adding that
value to the environment with the appropriate directories is the best
way to go.