### PR TITLE
INF-2266: Create emptyDir for zookeeper data directory

### DIFF
--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -127,6 +127,10 @@ spec:
           ZOOKEEPER_SERVERS=`echo $ZOOKEEPER_SERVERS | sed -e "$ZK_FIX_HOST_REGEX"` \
           /etc/confluent/docker/run
         volumeMounts:
+        {{- if .Values.securityContext.enabled }}
+        - name: dataroot
+          mountPath: /var/lib/zookeeper
+        {{- end }}
         - name: datadir
           mountPath: /var/lib/zookeeper/data
         - name: datalogdir
@@ -136,6 +140,12 @@ spec:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
       volumes:
+      # Create an emptyDir for the root of the zookeeper data directory, since 
+      # it is only writable by root in the image.
+      {{- if .Values.securityContext.enabled }}
+      - name: dataroot
+        emptyDir: {}
+      {{- end }}
       {{ if not .Values.persistence.enabled }}
       - name: datadir
         emptyDir: {}


### PR DESCRIPTION
If we're running with the security context enabled, we need to make sure
that the root directory that the log directory and data directory goes
into is _also_ writable by the unprivileged user. So, we create an
emptyDir volume there and K8s will fix the permissions for us.