### PR TITLE
INF-2266: Add emptyDir volume for /etc/kafka in the kafka image

### DIFF
--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -152,6 +152,10 @@ spec:
         - name: datadir-{{$k}}
           mountPath: /opt/kafka/data-{{$k}}
         {{- end }}
+        {{- if .Values.securityContext.enabled }}
+        - name: etc
+          mountPath: /etc/kafka
+        {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
@@ -175,6 +179,11 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
       {{- if .Values.securityContext.enabled }}
+      volumes:
+        {{- if .Values.securityContext.enabled }}
+        - name: etc
+          emptyDir: {}
+        {{- end }}
       securityContext:
 {{ toYaml .Values.securityContext.spec | indent 8 }}
       {{- end }}


### PR DESCRIPTION
I should have known I'd have to make this fix twice.
