### PR TITLE
INF-5590: Change poddisruption budget API version

### DIFF
--- a/charts/cp-zookeeper/templates/poddisruptionbudget.yaml
+++ b/charts/cp-zookeeper/templates/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "cp-zookeeper.fullname" . }}-pdb


### PR DESCRIPTION
Update the ZooKeeper poddisruptionbudget to use the new API version.
It appears that PDB for Kafka was previously removed from our fork.

Confirmed  PDBs are only being created for ZooKeeper:

```
kubectl get poddisruptionbudget -A
NAMESPACE     NAME                                     MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
kafka         staging-kafka-cp-zookeeper-pdb           3               N/A               0                     686d
kafka         staging-kafka-primary-cp-zookeeper-pdb   3               N/A               2                     3y143d
```